### PR TITLE
add support for docker and more commads for git

### DIFF
--- a/PowerType/Dictionaries/docker.ps1
+++ b/PowerType/Dictionaries/docker.ps1
@@ -1,0 +1,150 @@
+﻿# Dynamic sources
+$containers = [DynamicSource]@{
+    Name = "Containers";
+    Description = "List of running containers";
+    CommandExpression = { docker ps --format "{{.Names}}" };
+    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+}
+
+$allContainers = [DynamicSource]@{
+    Name = "All Containers";
+    Description = "List of all containers (running + stopped)";
+    CommandExpression = { docker ps -a --format "{{.Names}}" };
+    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+}
+
+$images = [DynamicSource]@{
+    Name = "Images";
+    Description = "List of Docker images";
+    CommandExpression = { docker images --format "{{.Repository}}:{{.Tag}}" };
+    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 30 }
+}
+
+$volumes = [DynamicSource]@{
+    Name = "Volumes";
+    Description = "List of Docker volumes";
+    CommandExpression = { docker volume ls --format "{{.Name}}" };
+    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 30 }
+}
+
+$dockerContexts = [DynamicSource]@{
+    Name = "Docker Contexts";
+    Description = "List of Docker contexts";
+    CommandExpression = { docker context ls --format "{{.Name}}" };
+    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+}
+
+# Docker PowerTypeDictionary
+[PowerTypeDictionary]@{
+    Keys        = @("docker");
+    Name        = "Docker";
+    Description = "Docker CLI management";
+    Platforms   = [Platforms]::All;
+    State       = [DictionaryState]::Experimental -bor [DictionaryState]::Incomplete;
+    Source      = "Hand crafted";
+    Url         = "https://docs.docker.com/engine/reference/commandline/cli/";
+    Parameters  = @(
+        # Containers
+        [CommandParameter]@{
+            Keys = @("ps");
+            Name = "ps";
+            Description = "List containers";
+            Parameters = @(
+                [FlagParameter]@{ Keys=@("-a","--all"); Name="all"; Description="Show all containers" }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("run");
+            Name = "run";
+            Description = "Run a new container";
+            Parameters = @(
+                [ValueParameter]@{ Name="image"; Description="Image to run"; Source=$images }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("exec");
+            Name = "exec";
+            Description = "Run command in a running container";
+            Parameters = @(
+                [ValueParameter]@{ Name="container"; Description="Container to exec into"; Source=$containers }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("stop");
+            Name = "stop";
+            Description = "Stop container(s)";
+            Parameters = @(
+                [ValueParameter]@{ Name="container"; Description="Container to stop"; Source=$containers }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("rm");
+            Name = "rm";
+            Description = "Remove container(s)";
+            Parameters = @(
+                [ValueParameter]@{ Name="container"; Description="Container to remove"; Source=$allContainers }
+            )
+        },
+
+        # Images
+        [CommandParameter]@{ Keys=@("images"); Name="images"; Description="List images" },
+        [CommandParameter]@{ Keys=@("rmi"); Name="rmi"; Description="Remove image"; Parameters=@(
+            [ValueParameter]@{ Name="image"; Description="Image to remove"; Source=$images }
+        )},
+        [CommandParameter]@{ Keys=@("tag"); Name="tag"; Description="Tag an image"; Parameters=@(
+            [ValueParameter]@{ Name="image"; Description="Image to tag"; Source=$images }
+        )},
+        [CommandParameter]@{ Keys=@("push"); Name="push"; Description="Push an image to registry"; Parameters=@(
+            [ValueParameter]@{ Name="image"; Description="Image to push"; Source=$images }
+        )},
+        [CommandParameter]@{ Keys=@("pull"); Name="pull"; Description="Pull an image"; Parameters=@(
+            [ValueParameter]@{ Name="image"; Description="Image to pull"; Source=$images }
+        )},
+
+        # Contexts
+        [CommandParameter]@{
+            Keys = @("context");
+            Name = "context";
+            Description = "Manage Docker contexts";
+            Parameters = @(
+                [ValueParameter]@{ Keys=@("ls"); Name="ls"; Description="List contexts" },
+                [ValueParameter]@{ Keys=@("inspect"); Name="inspect"; Description="Inspect context"; Source=$dockerContexts },
+                [ValueParameter]@{ Keys=@("use"); Name="use"; Description="Switch context"; Source=$dockerContexts }
+            )
+        },
+
+        # System
+        [CommandParameter]@{
+            Keys=@("system");
+            Name="system";
+            Description="Inspect/manage Docker system";
+            Parameters=@(
+                [ValueParameter]@{ Keys=@("df"); Name="df"; Description="Show disk usage" },
+                [ValueParameter]@{ Keys=@("prune"); Name="prune"; Description="Remove unused objects" },
+                [ValueParameter]@{ Keys=@("info"); Name="info"; Description="Show system info" },
+                [ValueParameter]@{ Keys=@("events"); Name="events"; Description="Show events log" }
+            )
+        },
+
+        # Volumes
+        [CommandParameter]@{
+            Keys=@("volume");
+            Name="volume";
+            Description="Manage volumes";
+            Parameters=@(
+                [ValueParameter]@{ Keys=@("ls"); Name="ls"; Description="List volumes"; Source=$volumes },
+                [ValueParameter]@{ Keys=@("rm"); Name="rm"; Description="Remove volume"; Source=$volumes }
+            )
+        },
+
+        # Networks, Plugins, Swarm, Logs
+        [CommandParameter]@{ Keys=@("network"); Name="network"; Description="Manage networks" },
+        [CommandParameter]@{ Keys=@("plugin"); Name="plugin"; Description="Manage plugins"; Parameters=@(
+            [ValueParameter]@{ Keys=@("install"); Name="install"; Description="Install plugin" }
+        )},
+        [CommandParameter]@{ Keys=@("swarm"); Name="swarm"; Description="Manage swarm" },
+        [CommandParameter]@{ Keys=@("logs"); Name="logs"; Description="Show container logs"; Parameters=@(
+            [ValueParameter]@{ Name="container"; Description="Container to show logs"; Source=$containers }
+        )}
+    )
+}

--- a/PowerType/Dictionaries/docker.ps1
+++ b/PowerType/Dictionaries/docker.ps1
@@ -2,36 +2,60 @@
 $containers = [DynamicSource]@{
     Name = "Containers";
     Description = "List of running containers";
-    CommandExpression = { docker ps --format "{{.Names}}" };
-    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+    CommandExpression = { 
+        docker ps --format "{{.Names}}" 
+    };
+    Cache = [Cache]@{
+        ByCurrentWorkingDirectory = $true;
+        ByTime = New-TimeSpan -Seconds 10 ;
+        ByCommand = @("kill", "run", "stop", "start","rm","pause")
+    }
 }
 
 $allContainers = [DynamicSource]@{
     Name = "All Containers";
     Description = "List of all containers (running + stopped)";
-    CommandExpression = { docker ps -a --format "{{.Names}}" };
-    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+    CommandExpression = { 
+        docker ps -a --format "{{.Names}}" 
+    };
+    Cache = [Cache]@{ 
+        ByCurrentWorkingDirectory = $true;
+        ByTime = New-TimeSpan -Seconds 10 ;
+        ByCommand = @("kill", "run", "stop", "start","rm","pause")
+    }
 }
 
 $images = [DynamicSource]@{
     Name = "Images";
     Description = "List of Docker images";
-    CommandExpression = { docker images --format "{{.Repository}}:{{.Tag}}" };
-    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 30 }
+    CommandExpression = { 
+        docker images --format "{{.Repository}}:{{.Tag}}" 
+    };
+    Cache = [Cache]@{ 
+        ByTime = New-TimeSpan -Seconds 30 
+    }
 }
 
 $volumes = [DynamicSource]@{
     Name = "Volumes";
     Description = "List of Docker volumes";
-    CommandExpression = { docker volume ls --format "{{.Name}}" };
-    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 30 }
+    CommandExpression = { 
+        docker volume ls --format "{{.Name}}" 
+    };
+    Cache = [Cache]@{ 
+        ByTime = New-TimeSpan -Seconds 30 
+    }
 }
 
 $dockerContexts = [DynamicSource]@{
     Name = "Docker Contexts";
     Description = "List of Docker contexts";
-    CommandExpression = { docker context ls --format "{{.Name}}" };
-    Cache = [Cache]@{ ByTime = New-TimeSpan -Seconds 10 }
+    CommandExpression = { 
+        docker context ls --format "{{.Name}}" 
+    };
+    Cache = [Cache]@{ 
+        ByTime = New-TimeSpan -Seconds 10 
+    }
 }
 
 # Docker PowerTypeDictionary
@@ -50,7 +74,11 @@ $dockerContexts = [DynamicSource]@{
             Name = "ps";
             Description = "List containers";
             Parameters = @(
-                [FlagParameter]@{ Keys=@("-a","--all"); Name="all"; Description="Show all containers" }
+                [FlagParameter]@{ 
+                    Keys=@("-a","--all"); 
+                    Name="all"; 
+                    Description="Show all containers" 
+                }
             )
         },
         [CommandParameter]@{
@@ -58,7 +86,11 @@ $dockerContexts = [DynamicSource]@{
             Name = "run";
             Description = "Run a new container";
             Parameters = @(
-                [ValueParameter]@{ Name="image"; Description="Image to run"; Source=$images }
+                [ValueParameter]@{ 
+                    Name="image"; 
+                    Description="Image to run"; 
+                    Source=$images 
+                }
             )
         },
         [CommandParameter]@{
@@ -66,7 +98,11 @@ $dockerContexts = [DynamicSource]@{
             Name = "exec";
             Description = "Run command in a running container";
             Parameters = @(
-                [ValueParameter]@{ Name="container"; Description="Container to exec into"; Source=$containers }
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to exec into"; 
+                    Source=$containers 
+                }
             )
         },
         [CommandParameter]@{
@@ -74,7 +110,11 @@ $dockerContexts = [DynamicSource]@{
             Name = "stop";
             Description = "Stop container(s)";
             Parameters = @(
-                [ValueParameter]@{ Name="container"; Description="Container to stop"; Source=$containers }
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to stop"; 
+                    Source=$containers 
+                }
             )
         },
         [CommandParameter]@{
@@ -82,24 +122,67 @@ $dockerContexts = [DynamicSource]@{
             Name = "rm";
             Description = "Remove container(s)";
             Parameters = @(
-                [ValueParameter]@{ Name="container"; Description="Container to remove"; Source=$allContainers }
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to remove"; 
+                    Source=$allContainers 
+                }
             )
         },
-
         # Images
-        [CommandParameter]@{ Keys=@("images"); Name="images"; Description="List images" },
-        [CommandParameter]@{ Keys=@("rmi"); Name="rmi"; Description="Remove image"; Parameters=@(
-            [ValueParameter]@{ Name="image"; Description="Image to remove"; Source=$images }
-        )},
-        [CommandParameter]@{ Keys=@("tag"); Name="tag"; Description="Tag an image"; Parameters=@(
-            [ValueParameter]@{ Name="image"; Description="Image to tag"; Source=$images }
-        )},
-        [CommandParameter]@{ Keys=@("push"); Name="push"; Description="Push an image to registry"; Parameters=@(
-            [ValueParameter]@{ Name="image"; Description="Image to push"; Source=$images }
-        )},
-        [CommandParameter]@{ Keys=@("pull"); Name="pull"; Description="Pull an image"; Parameters=@(
-            [ValueParameter]@{ Name="image"; Description="Image to pull"; Source=$images }
-        )},
+        [CommandParameter]@{ 
+            Keys=@("images"); 
+            Name="images"; 
+            Description="List images" 
+        },
+        [CommandParameter]@{ 
+            Keys=@("rmi");
+            Name="rmi"; 
+            Description="Remove image"; 
+            Parameters=@(
+                [ValueParameter]@{ 
+                    Name="image"; 
+                    Description="Image to remove"; 
+                    Source=$images 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("tag"); 
+            Name="tag"; 
+            Description="Tag an image"; 
+            Parameters=@(
+                [ValueParameter]@{ 
+                    Name="image"; 
+                    Description="Image to tag"; 
+                    Source=$images 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("push"); 
+            Name="push"; 
+            Description="Push an image to registry"; 
+            Parameters=@(
+                [ValueParameter]@{ 
+                    Name="image"; 
+                    Description="Image to push"; 
+                    Source=$images 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("pull"); 
+            Name="pull"; 
+            Description="Pull an image"; 
+            Parameters=@(
+                [ValueParameter]@{ 
+                    Name="image"; 
+                    Description="Image to pull"; 
+                    Source=$images 
+                }
+            )
+        },
 
         # Contexts
         [CommandParameter]@{
@@ -107,9 +190,23 @@ $dockerContexts = [DynamicSource]@{
             Name = "context";
             Description = "Manage Docker contexts";
             Parameters = @(
-                [ValueParameter]@{ Keys=@("ls"); Name="ls"; Description="List contexts" },
-                [ValueParameter]@{ Keys=@("inspect"); Name="inspect"; Description="Inspect context"; Source=$dockerContexts },
-                [ValueParameter]@{ Keys=@("use"); Name="use"; Description="Switch context"; Source=$dockerContexts }
+                [ValueParameter]@{ 
+                    Keys=@("ls"); 
+                    Name="ls"; 
+                    Description="List contexts" 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("inspect"); 
+                    Name="inspect"; 
+                    Description="Inspect context"; 
+                    Source=$dockerContexts 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("use"); 
+                    Name="use"; 
+                    Description="Switch context"; 
+                    Source=$dockerContexts 
+                }
             )
         },
 
@@ -119,10 +216,26 @@ $dockerContexts = [DynamicSource]@{
             Name="system";
             Description="Inspect/manage Docker system";
             Parameters=@(
-                [ValueParameter]@{ Keys=@("df"); Name="df"; Description="Show disk usage" },
-                [ValueParameter]@{ Keys=@("prune"); Name="prune"; Description="Remove unused objects" },
-                [ValueParameter]@{ Keys=@("info"); Name="info"; Description="Show system info" },
-                [ValueParameter]@{ Keys=@("events"); Name="events"; Description="Show events log" }
+                [ValueParameter]@{ 
+                    Keys=@("df"); 
+                    Name="df"; 
+                    Description="Show disk usage" 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("prune"); 
+                    Name="prune"; 
+                    Description="Remove unused objects" 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("info"); 
+                    Name="info"; 
+                    Description="Show system info" 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("events"); 
+                    Name="events"; 
+                    Description="Show events log" 
+                }
             )
         },
 
@@ -132,19 +245,90 @@ $dockerContexts = [DynamicSource]@{
             Name="volume";
             Description="Manage volumes";
             Parameters=@(
-                [ValueParameter]@{ Keys=@("ls"); Name="ls"; Description="List volumes"; Source=$volumes },
-                [ValueParameter]@{ Keys=@("rm"); Name="rm"; Description="Remove volume"; Source=$volumes }
+                [ValueParameter]@{ 
+                    Keys=@("ls"); 
+                    Name="ls"; 
+                    Description="List volumes"; 
+                    Source=$volumes 
+                },
+                [ValueParameter]@{ 
+                    Keys=@("rm"); 
+                    Name="rm"; 
+                    Description="Remove volume"; 
+                    Source=$volumes 
+                }
             )
         },
 
         # Networks, Plugins, Swarm, Logs
-        [CommandParameter]@{ Keys=@("network"); Name="network"; Description="Manage networks" },
-        [CommandParameter]@{ Keys=@("plugin"); Name="plugin"; Description="Manage plugins"; Parameters=@(
-            [ValueParameter]@{ Keys=@("install"); Name="install"; Description="Install plugin" }
-        )},
-        [CommandParameter]@{ Keys=@("swarm"); Name="swarm"; Description="Manage swarm" },
-        [CommandParameter]@{ Keys=@("logs"); Name="logs"; Description="Show container logs"; Parameters=@(
-            [ValueParameter]@{ Name="container"; Description="Container to show logs"; Source=$containers }
-        )}
+        [CommandParameter]@{ 
+            Keys=@("network"); 
+            Name="network"; 
+            Description="Manage networks" 
+        },
+        [CommandParameter]@{ 
+            Keys=@("plugin"); 
+            Name="plugin"; 
+            Description="Manage plugins"; 
+            Parameters=@(
+            [ValueParameter]@{ 
+                Keys=@("install"); 
+                Name="install"; 
+                Description="Install plugin" }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("swarm"); 
+            Name="swarm"; 
+            Description="Manage swarm" 
+        },
+        [CommandParameter]@{ 
+            Keys=@("logs"); 
+            Name="logs"; 
+            Description="Show container logs"; 
+            Parameters=@(
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to show logs"; 
+                    Source=$containers 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("start"); 
+            Name="start"; 
+            Description="Start one or more stopped containers."; 
+            Parameters = @(
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to start."; 
+                    Source=$containers 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("pause"); 
+            Name="pause"; 
+            Description="Pause all processes within one or more containers."; 
+            Parameters = @(
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to pause."; 
+                    Source=$containers 
+                }
+            )
+        },
+        [CommandParameter]@{ 
+            Keys=@("unpause"); 
+            Name="unpause"; 
+            Description="Unpause all processes within one or more containers."; 
+            Parameters = @(
+                [ValueParameter]@{ 
+                    Name="container"; 
+                    Description="Container to unpause."; 
+                    Source=$containers 
+                }
+            )
+        }
     )
 }

--- a/PowerType/Dictionaries/git.ps1
+++ b/PowerType/Dictionaries/git.ps1
@@ -1159,6 +1159,7 @@ $archiveFormats = [DynamicSource]@{
                 }
             )
         },
+
         [CommandParameter]@{
             Keys = @("clone");
             Name = "clone";
@@ -3994,6 +3995,243 @@ $archiveFormats = [DynamicSource]@{
                     Keys = @("--first-parent");
                     Name = "first-parent";
                     Description = "Follow only the first parent commit upon seeing a merge commit.";
+                }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("remote");
+            Name = "remote";
+            Description = "Manage set of tracked repositories";
+            Parameters = @(
+                [FlagParameter]@{
+                    Keys = @("-v", "--verbose");
+                    Name = "verbose";
+                    Description = "Be more verbose, show remote URLs after the remote name";
+                },
+                [CommandParameter]@{
+                    Keys = @("add");
+                    Name = "add";
+                    Description = "Add a remote repository";
+                    Parameters = @(
+                        [ValueParameter]@{
+                            Name = "name";
+                            Description = "Name of the remote to add";
+                        },
+                        [ValueParameter]@{
+                            Name = "url";
+                            Description = "URL of the remote repository";
+                        }
+                    )
+                },
+                [CommandParameter]@{
+                    Keys = @("remove", "rm");
+                    Name = "remove";
+                    Description = "Remove a remote repository";
+                    Parameters = @(
+                        [ValueParameter]@{
+                            Name = "name";
+                            Description = "Name of the remote to remove";
+                            Source = $remotes
+                        }
+                    )
+                }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("init");
+            Name = "init";
+            Description = "Create an empty Git repository or reinitialize an existing one";
+            Parameters = @(
+                [FlagParameter]@{
+                    Keys = @("--quiet", "-q");
+                    Name = "quiet";
+                    Description = "Only print error and warning messages; all other output will be suppressed.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--bare");
+                    Name = "bare";
+                    Description = "Create a bare repository. If GIT_DIR is not set, it is set to the current working directory.";
+                },
+                [ValueParameter]@{
+                    Keys = @("--template");
+                    Name = "template";
+                    Description = "Specify the directory from which templates will be used.";
+                    #Source = Directory
+                },
+                [ValueParameter]@{
+                    Keys = @("--separate-git-dir");
+                    Name = "separate-git-dir";
+                    Description = "Instead of initializing the repository in $GIT_DIR or ./.git/, create a text file there containing the path to the actual repository.";
+                    #Source = Directory
+                },
+                [ValueParameter]@{
+                    Keys = @("--initial-branch", "-b");
+                    Name = "initial-branch";
+                    Description = "Use the specified name for the initial branch in the newly created repository.";
+                },
+                [ValueParameter]@{
+                    Keys = @("--shared");
+                    Name = "shared";
+                    Description = "Specify that the Git repository is to be shared amongst several users. This allows users belonging to the same group to push into that repository. When specified, the config variable `core.sharedRepository` is set so that files and directories under $GIT_DIR are created with the requested permissions. When not specified, Git will use permissions reported by umask(2).";
+                    #Source = "umask", "group", "all"
+                },
+                [ValueParameter]@{
+                    Keys = @("--object-format");
+                    Name = "object-format";
+                    Description = "Specify the given object format (hash algorithm) for the repository. The valid values are sha1 and (if enabled) sha256. sha1 is the default.";
+                    Condition = [LargerOrEqualCondition]::new($version, [Version]'2.29.0');
+                    #Source = "sha1", "sha256"
+                },
+                [ValueParameter]@{
+                    Name = "directory";
+                    Description = "The directory in which to create the repository. Can be a new or existing empty directory.";
+                    #Source = Directory
+                }
+            )
+        },
+        [CommandParameter]@{
+            Keys = @("pull");
+            Name = "pull";
+            Description = "Fetch from and integrate with another repository or a local branch";
+            Parameters = @(
+                # General Options
+                [FlagParameter]@{
+                    Keys = @("--quiet", "-q");
+                    Name = "quiet";
+                    Description = "Operate quietly. This is passed to both underlying git-fetch and git-merge.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--verbose", "-v");
+                    Name = "verbose";
+                    Description = "Pass --verbose to git-fetch and git-merge.";
+                },
+
+                # Merge/Rebase Strategy Options
+                [ValueParameter]@{
+                    Keys = @("--rebase", "-r");
+                    Name = "rebase";
+                    Description = "Rebase the current branch on top of the upstream branch after fetching. Can be 'true', 'false', 'merges', or 'interactive'.";
+                    Condition = [ExclusiveParameterCondition]::new("no-rebase");
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-rebase");
+                    Name = "no-rebase";
+                    Description = "Override the pull.rebase configuration variable to prevent rebasing.";
+                    Condition = [ExclusiveParameterCondition]::new("rebase");
+                },
+                [FlagParameter]@{
+                    Keys = @("--ff");
+                    Name = "ff";
+                    Description = "Only fast-forward the branch. This is the default.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-ff");
+                    Name = "no-ff";
+                    Description = "Create a merge commit even when the merge resolves as a fast-forward.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--ff-only");
+                    Name = "ff-only";
+                    Description = "Refuse to merge and exit with a non-zero status unless it can be resolved as a fast-forward.";
+                },
+                [ValueParameter]@{
+                    Keys = @("--strategy", "-s");
+                    Name = "strategy";
+                    Description = "Use the given merge strategy (e.g., 'recursive', 'resolve', 'octopus', 'ours', 'subtree').";
+                },
+                [ValueParameter]@{
+                    Keys = @("--strategy-option", "-X");
+                    Name = "strategy-option";
+                    Description = "Pass a merge strategy-specific option through to the merge strategy.";
+                },
+
+                # Commit Options
+                [FlagParameter]@{
+                    Keys = @("--commit");
+                    Name = "commit";
+                    Description = "Perform the merge and commit the result. This can be used to override --no-commit.";
+                    Condition = [ExclusiveParameterCondition]::new("no-commit", "squash");
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-commit");
+                    Name = "no-commit";
+                    Description = "Perform the merge but stop before creating a merge commit.";
+                    Condition = [ExclusiveParameterCondition]::new("commit");
+                },
+                [FlagParameter]@{
+                    Keys = @("--edit", "-e");
+                    Name = "edit";
+                    Description = "Invoke an editor before committing to edit the auto-generated merge message.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-edit");
+                    Name = "no-edit";
+                    Description = "Accept the auto-generated merge message without launching an editor.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--squash");
+                    Name = "squash";
+                    Description = "Produce the working tree and index state as if a real merge happened, but do not actually make a commit or move the HEAD.";
+                    Condition = [ExclusiveParameterCondition]::new("commit");
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-squash");
+                    Name = "no-squash";
+                    Description = "Perform the merge and commit the result. This option can be used to override --squash.";
+                },
+
+                # Fetching Options
+                [FlagParameter]@{
+                    Keys = @("--all");
+                    Name = "all";
+                    Description = "Fetch all remotes.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--force", "-f");
+                    Name = "force";
+                    Description = "Forces the fetch to overwrite a local branch even if it's not an ancestor of the remote branch.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--prune", "-p");
+                    Name = "prune";
+                    Description = "Before fetching, remove any remote-tracking references that no longer exist on the remote.";
+                },
+                [ValueParameter]@{
+                    Keys = @("--depth");
+                    Name = "depth";
+                    Description = "Limit fetching to the specified number of commits from the tip of each remote branch history.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--unshallow");
+                    Name = "unshallow";
+                    Description = "Convert a shallow repository to a complete one, removing all shallow limitations.";
+                },
+
+                # Other Behavior Options
+                [FlagParameter]@{
+                    Keys = @("--autostash");
+                    Name = "autostash";
+                    Description = "Automatically create a temporary stash before the operation begins and apply it after.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--no-autostash");
+                    Name = "no-autostash";
+                    Description = "Do not automatically create a stash. Overrides autostash configuration.";
+                },
+                [FlagParameter]@{
+                    Keys = @("--allow-unrelated-histories");
+                    Name = "allow-unrelated-histories";
+                    Description = "Allows merging two projects that have unrelated histories.";
+                },
+        
+                # Positional Arguments
+                [ValueParameter]@{
+                    Name = "repository";
+                    Description = "The 'remote' repository to pull from (e.g., 'origin').";
+                },
+                [ValueParameter]@{
+                    Name = "refspec";
+                    Description = "Specifies which refs to fetch and which local refs to update (e.g., 'main', 'dev:dev').";
                 }
             )
         }

--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ This project is far from done but has the aim to provide autocomplete for common
 
 # How it work
 PowerType integrates with **PSReadLine** to provide command predictions.  
-It works by:
-- Reading your command history (for context and suggestions).  
+It works by: 
 - Loading dictionaries (`.ps1` files) that describe parameters and subcommands for different tools.  
 - Displaying completions in real time as you type in the console. 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - [Uninstall](#uninstall)
 - [Troubleshooting](#troubleshooting)
 - [Progress](#progress)
-- [How it works](#How it works)
+- [How it work](#how-it-work)
 - [Contribute](#contribute)
 - [Acknowledgements](#acknowledgements)
 
@@ -89,7 +89,7 @@ Get-PowerTypeHistory # Used to see if any suggestions caused a exception
 
 This project is far from done but has the aim to provide autocomplete for common cli tools like [git](PowerType/Dictionaries/git.ps1), [npm](PowerType/Dictionaries/npm.ps1), [adb](PowerType/Dictionaries/adb.ps1), docker, dotnet, node and many more while using powershell. 
 
-# How it works
+# How it work
 PowerType integrates with **PSReadLine** to provide command predictions.  
 It works by:
 - Reading your command history (for context and suggestions).  

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Uninstall](#uninstall)
 - [Troubleshooting](#troubleshooting)
 - [Progress](#progress)
+- [How it works](#How it works)
 - [Contribute](#contribute)
 - [Acknowledgements](#acknowledgements)
 
@@ -87,6 +88,21 @@ Get-PowerTypeHistory # Used to see if any suggestions caused a exception
 [![GitHub milestone](https://img.shields.io/github/milestones/progress/AnderssonPeter/PowerType/4?style=flat-square)](https://github.com/AnderssonPeter/PowerType/milestone/4)
 
 This project is far from done but has the aim to provide autocomplete for common cli tools like [git](PowerType/Dictionaries/git.ps1), [npm](PowerType/Dictionaries/npm.ps1), [adb](PowerType/Dictionaries/adb.ps1), docker, dotnet, node and many more while using powershell. 
+
+# How it works
+PowerType integrates with **PSReadLine** to provide command predictions.  
+It works by:
+- Reading your command history (for context and suggestions).  
+- Loading dictionaries (`.ps1` files) that describe parameters and subcommands for different tools.  
+- Displaying completions in real time as you type in the console. 
+
+Currently, PowerType provides autocomplete dictionaries for tools such as:  
+- **adb** 
+- **docker** ✅ *(newly supported)*  
+- **git**  ✅ *(more commands)*  
+- **npm**  working on more commands
+- **Android Debug Bridge**
+- **powershell**  *(coming soon)*
 
 # Contribute
 If you wish to contribute the following would be greatly appreciated


### PR DESCRIPTION
Added a new dictionary for Docker in PowerType, enabling autocomplete for common Docker commands and parameters.

✅ Main changes

Created the docker.ps1 dictionary file.

Implemented basic commands (docker run, docker build, docker ps, etc.).

Integrated with PSReadLine to provide real-time suggestions.

🔍 Notes

This initial dictionary covers the most commonly used commands, but it can be extended with more subcommands in future updates.

Tested on Windows with PowerShell 7.2.